### PR TITLE
[Feature] url_for_authentication works with scope

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -148,7 +148,7 @@ module Nylas
         :client_id => @app_id,
         :trial => options.fetch(:trial, false),
         :response_type => 'code',
-        :scope => 'email',
+        :scope => (options[:scope] || 'email'),
         :login_hint => login_hint,
         :redirect_uri => redirect_uri,
       }


### PR DESCRIPTION
N.B. From our Nylas, account, it looks like we are using API version 1.0.

<img width="131" alt="Screenshot 2019-06-30 00 07 48" src="https://user-images.githubusercontent.com/2191808/60393490-1e5d9980-9acb-11e9-9a42-2781734c6afc.png">

We need to support scopes for Nylas, namely, restrict the scope to access only the Google calendar.  From the [documentation for API version 1.0](https://docs.nylas.com/v1.0/reference#oauth), we see the way to do this is to pass in the `scopes` query param for the `connect/authorize` endpoint:

```
curl --request GET \
  --url 'https://api.nylas.com/oauth/authorize?client_id=client_id&response_type=response_type&scope=email&login_hint=login_hint&redirect_uri=redirect_uri' \
  --header 'authorization: vVX4pibJbmbhPEomjX7jiXL2PeVsRQ'
```
We use the Nylas gem to derive this URL, in this line of code: https://github.com/onboardiq/nylas-ruby/blob/master/lib/nylas.rb#L146L161 However, notice that `scope` is just hard-coded to `email`.  This PR changes this and uses a `scope` value that we can pass in.